### PR TITLE
Added new field-value pair for iPython session timeout feature.

### DIFF
--- a/conf.yml
+++ b/conf.yml
@@ -13,3 +13,5 @@ daq_host: drp-srcf-cmp004
 
 daq_platform:
   default: 2
+
+session_timer: 172800


### PR DESCRIPTION
Added `session_timer: 172800` for the IPython session timer to conf.yml.